### PR TITLE
Prefer "groupId" over "groupID"

### DIFF
--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -74,7 +74,7 @@ func SetupApp(ctx context.Context, ex *exec.Executor) error {
 		},
 		RequestBody:  mapper,
 		ResponseBody: true,
-		Endpoint:     "/applications?groupID={group_id}",
+		Endpoint:     "/applications?groupId={group_id}",
 		HTTPMethod:   "POST",
 		StatusCode:   201,
 	}
@@ -106,7 +106,7 @@ func SetupAppEndpoint(ctx context.Context, targetURL string, ex *exec.Executor) 
 		},
 		RequestBody:  mapper,
 		ResponseBody: true,
-		Endpoint:     "/applications/{app_id}/endpoints?groupID={group_id}",
+		Endpoint:     "/applications/{app_id}/endpoints?groupId={group_id}",
 		HTTPMethod:   "POST",
 		StatusCode:   201,
 	}
@@ -139,7 +139,7 @@ func SetupEvent(ctx context.Context, ex *exec.Executor) error {
 		},
 		RequestBody:  mapper,
 		ResponseBody: true,
-		Endpoint:     "/events?groupID={group_id}",
+		Endpoint:     "/events?groupId={group_id}",
 		HTTPMethod:   "POST",
 		StatusCode:   201,
 	}

--- a/immune.json
+++ b/immune.json
@@ -1,69 +1,59 @@
 {
-    "base_url": "http://127.0.0.1:5005/api/v1",
-    "callback": {
-        "port": 80,
-        "ssl": false,
-        "ssl_cert_file": "",
-        "ssl_key_file": "",
-        "max_wait_seconds": 20,
-        "route": "/",
-        "id_location": "data"
-    },
-    "database" : {
-        "type": "mongo",
-        "dsn": "mongodb+srv://admin:7h5tAfZiYuCEe6KC42873272642331@cluster1.eqj2e.mongodb.net/convoy-immune"
-    },
-    "event_target_url": "https://5721-102-219-153-96.ngrok.io",
-    "test_cases": [
-        {
-            "name": "test_convoy_can_push_event_to_app_with_one_endpoint",
-            "setup": [
-                "setup_group",
-                "setup_app",
-                "setup_endpoint",
-                "setup_event"
-            ],
-            "http_method": "POST",
-            "endpoint": "/events?groupID={group_id}",
-            "callback": {
-                "enabled": true,
-                "times": 2
-            },
-            "request_body": {
-                "app_id": "{app_id}",
-                "event_type": "payment.failed",
-                "data": {
-                    "sc": "gene",
-                    "marvel": "stark"
-                }
-            },
-            "status_code": 201,
-            "response_body": true
-        },
-        {
-            "name": "test_convoy_can_push_event_to_app_with_two_endpoint",
-            "setup": [
-                "setup_group",
-                "setup_app",
-                "setup_endpoint",
-                "setup_endpoint"
-            ],
-            "http_method": "POST",
-            "endpoint": "/events?groupID={group_id}",
-            "callback": {
-                "enabled": true,
-                "times": 2
-            },
-            "request_body": {
-                "app_id": "{app_id}",
-                "event_type": "payment.failed",
-                "data": {
-                    "sc": "gene",
-                    "marvel": "stark"
-                }
-            },
-            "status_code": 201,
-            "response_body": true
+  "base_url": "http://127.0.0.1:5005/api/v1",
+  "callback": {
+    "port": 80,
+    "ssl": false,
+    "ssl_cert_file": "",
+    "ssl_key_file": "",
+    "max_wait_seconds": 20,
+    "route": "/",
+    "id_location": "data"
+  },
+  "database": {
+    "type": "mongo",
+    "dsn": "mongodb+srv://admin:7h5tAfZiYuCEe6KC42873272642331@cluster1.eqj2e.mongodb.net/convoy-immune"
+  },
+  "event_target_url": "https://5721-102-219-153-96.ngrok.io",
+  "test_cases": [
+    {
+      "name": "test_convoy_can_push_event_to_app_with_one_endpoint",
+      "setup": ["setup_group", "setup_app", "setup_endpoint", "setup_event"],
+      "http_method": "POST",
+      "endpoint": "/events?groupId={group_id}",
+      "callback": {
+        "enabled": true,
+        "times": 2
+      },
+      "request_body": {
+        "app_id": "{app_id}",
+        "event_type": "payment.failed",
+        "data": {
+          "sc": "gene",
+          "marvel": "stark"
         }
-    ]
+      },
+      "status_code": 201,
+      "response_body": true
+    },
+    {
+      "name": "test_convoy_can_push_event_to_app_with_two_endpoint",
+      "setup": ["setup_group", "setup_app", "setup_endpoint", "setup_endpoint"],
+      "http_method": "POST",
+      "endpoint": "/events?groupId={group_id}",
+      "callback": {
+        "enabled": true,
+        "times": 2
+      },
+      "request_body": {
+        "app_id": "{app_id}",
+        "event_type": "payment.failed",
+        "data": {
+          "sc": "gene",
+          "marvel": "stark"
+        }
+      },
+      "status_code": 201,
+      "response_body": true
+    }
+  ]
 }


### PR DESCRIPTION
Convoy uses camel case `appId`, `endpointId` for query params, but the group id doesn't follow the convention, this has inadvertently broken `v0.5.x`